### PR TITLE
Add support for content URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ yarn add react-native-device-wallpaper-manager
 |Prop|Type|Description|Note|
 |-|-|-|-|
 |**destination**|string| type of wallpaper|"system", "both", "lock"|
-|**imageUri**|string|path to image (remote or local uri are acceptable)|"http://", "https://", "file://"|
+|**imageUri**|string|path to image (remote or local uri are acceptable)|"http://", "https://", "file://", "content://"|
 
 
 ### Example

--- a/android/src/main/java/com/rtn_device_wallpaper/DeviceWallpaperModule.kt
+++ b/android/src/main/java/com/rtn_device_wallpaper/DeviceWallpaperModule.kt
@@ -8,13 +8,16 @@ import android.graphics.drawable.BitmapDrawable
 import android.media.ThumbnailUtils
 import android.os.Build
 import android.util.DisplayMetrics
+import androidx.core.net.toUri
 import androidx.window.layout.WindowMetricsCalculator
 import coil.ImageLoader
 import coil.request.ImageRequest
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.IOException
 
 
@@ -66,6 +69,15 @@ class DeviceWallpaperModule(reactContext: ReactApplicationContext) : NativeDevic
                 }
         } else if (imageUri.startsWith("file://")) {
             bitmap = BitmapFactory.decodeFile(imageUri.replace("file://", ""))
+        } else if (imageUri.startsWith("content://")) {
+            val uri = imageUri.toUri()
+            val inputStream = context.contentResolver.openInputStream(uri)
+            if (inputStream != null) {
+                bitmap = BitmapFactory.decodeStream(inputStream)
+                withContext(Dispatchers.IO) {
+                    inputStream.close()
+                }
+            }
         }
         return bitmap
     }

--- a/android/src/main/java/com/rtn_device_wallpaper/DeviceWallpaperPackage.kt
+++ b/android/src/main/java/com/rtn_device_wallpaper/DeviceWallpaperPackage.kt
@@ -1,6 +1,6 @@
 package com.rtn_device_wallpaper;
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
@@ -17,11 +17,11 @@ enum class DESTINATION(val value:String){
   SYSTEM("system")
 }
 
-class DeviceWallpaperPackage : TurboReactPackage() {
+class DeviceWallpaperPackage : BaseReactPackage() {
 
-  override fun getModule(name: String, reactAppContext: ReactApplicationContext): NativeModule? {
+  override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
     if(name==DeviceWallpaperModule.NAME){
-      return DeviceWallpaperModule(reactAppContext)
+      return DeviceWallpaperModule(reactContext)
     }
     else{
     return null
@@ -31,7 +31,7 @@ class DeviceWallpaperPackage : TurboReactPackage() {
   override fun getReactModuleInfoProvider()=ReactModuleInfoProvider {
     mapOf(
       DeviceWallpaperModule.NAME to ReactModuleInfo(
-        DeviceWallpaperModule.NAME,DeviceWallpaperModule.NAME,false,false,true,false,true
+        DeviceWallpaperModule.NAME,DeviceWallpaperModule.NAME,false,false,false,true
       )
     )
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-device-wallpaper-manager",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "React Native New Architecture - device wallpaper setter library (Android only), backed with Coil and Coroutine ",
     "react-native": "js/index",
     "source": "js/index",


### PR DESCRIPTION
This pull request adds support for `content://` URIs and migrates from `TurboReactPackage` to `BaseReactPackage` because the former is deprecated.

Fixes: https://github.com/trieulongben/react-native-wallpaper-manager/issues/3

